### PR TITLE
Remove not required params

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -134,7 +134,7 @@ final class Connection
         return substr($ticket, 0, $pos);
     }
 
-    public function getTicket(array $args)
+    public function getTicket(array $args = [])
     {
         if (array_key_exists('pin', $args)) {
             $pin = $args['pin'];


### PR DESCRIPTION
Method `getTicket` require to use empty array in case default params:

```php
$connection->getTitcket([]);
```

With default params:
```php
$connection->getTitcket();
```